### PR TITLE
Cleaning and Optimization

### DIFF
--- a/src/Core/Game.cpp
+++ b/src/Core/Game.cpp
@@ -13,7 +13,7 @@ Game::~Game() {}
 
 void Game::run() {
 	while (window->isOpen()) {
-		window->poolEvents();
+		window->pollEvents();
 		update(clock.restart().asSeconds());
 
 		window->clear();

--- a/src/Core/State/State.cpp
+++ b/src/Core/State/State.cpp
@@ -2,7 +2,7 @@
 
 using namespace ExiledHeroes;
 
-State::State() {};
+State::State() {}
 State::~State() {}
 
 void ExiledHeroes::State::onSelect(StatePtr& from) {}

--- a/src/Core/State/State.cpp
+++ b/src/Core/State/State.cpp
@@ -5,9 +5,9 @@ using namespace ExiledHeroes;
 State::State() {}
 State::~State() {}
 
-void ExiledHeroes::State::onSelect(StatePtr& from) {}
+void ExiledHeroes::State::onSelect(State* from) {}
 
-void ExiledHeroes::State::onChange(StatePtr& to) {}
+void ExiledHeroes::State::onChange(State* to) {}
 
 void State::draw(sf::RenderTarget& target, sf::RenderStates states) const {}
 

--- a/src/Core/State/State.h
+++ b/src/Core/State/State.h
@@ -8,14 +8,12 @@
 namespace ExiledHeroes {
 	class State : public sf::Drawable, public Updatable
 	{
-	protected:
-		typedef std::shared_ptr<State> StatePtr;
 	public:
 		State();
 		virtual ~State();
 
-		virtual void onSelect(StatePtr& from);
-		virtual void onChange(StatePtr& to);
+		virtual void onSelect(State* from);
+		virtual void onChange(State* to);
 
 		virtual void draw(sf::RenderTarget& target, sf::RenderStates states) const;
 		virtual void update(float delta);

--- a/src/Core/State/StateHandler.cpp
+++ b/src/Core/State/StateHandler.cpp
@@ -17,9 +17,8 @@ StateHandler::StateHandler(int id, StatePtr state)
 
 StateHandler::~StateHandler() {}
 
-void StateHandler::setState(int id)
-{
-	try 
+void StateHandler::setState(int id) {
+	try
 	{
 		StatePtr& newState = states.at(id);
 		
@@ -32,13 +31,11 @@ void StateHandler::setState(int id)
 	catch (...) { currentState = states.at(0);}
 }
 
-void StateHandler::draw(sf::RenderTarget& target, sf::RenderStates states) const
-{
+void StateHandler::draw(sf::RenderTarget& target, sf::RenderStates states) const {
 	target.draw(*currentState, states);
 }
 
-void StateHandler::update(float delta)
-{
+void StateHandler::update(float delta) {
 	currentState->update(delta);
 }
 
@@ -47,7 +44,6 @@ void StateHandler::add(int id, StatePtr statePtr)
 	states.insert({ id, statePtr });
 }
 
-void StateHandler::remove(int id)
-{
+void StateHandler::remove(int id) {
 	states.erase(id);
 }

--- a/src/Core/State/StateHandler.h
+++ b/src/Core/State/StateHandler.h
@@ -12,13 +12,13 @@ namespace ExiledHeroes {
 
 	class StateHandler : public sf::Drawable, Updatable{
 	public:
-		typedef std::shared_ptr<State> StatePtr;
+		typedef std::unique_ptr<State> StatePtr;
 	private:
 		std::map<short, StatePtr> states;
-		StatePtr currentState;
+		State* currentState;
 	public:
 		StateHandler();
-		StateHandler(int id, StatePtr state);
+		StateHandler(int id, StatePtr& state);
 		~StateHandler();
 
 		void setState(int id);
@@ -26,7 +26,7 @@ namespace ExiledHeroes {
 		virtual void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 		void update(float delta);
 
-		void add(int id, StatePtr statePtr);
+		void add(int id, StatePtr& statePtr);
 		void remove(int id);
 	};
 }

--- a/src/Core/UI/Window.cpp
+++ b/src/Core/UI/Window.cpp
@@ -37,7 +37,7 @@ void Window::configure(WindowConfig config) {
 	createWindow();
 }
 
-void Window::poolEvents() {
+void Window::pollEvents() {
 	while (window->pollEvent(event)) {
 		if (event.type == sf::Event::Closed)
 			close();

--- a/src/Core/UI/Window.h
+++ b/src/Core/UI/Window.h
@@ -43,7 +43,7 @@ namespace ExiledHeroes {
 
 		void configure(WindowConfig config);
 
-		void poolEvents();
+		void pollEvents();
 		void setTitle(std::string name);
 		void close();
 	private:


### PR DESCRIPTION
### Summary
#### Optimization
- changed the `shared_ptr<State>` used in StateHandler class to `unique_ptr<State>`
- changed the `currentState` type from `shared_ptr<State>` to `State*`
 - changed the parameter type in method `onChange(std::shared_ptr<State>)` of State class, from `shared_ptr<State>` to `State*`
 - changed the parameter type in method `onSelect(std::shared_ptr<State>)` of State class, from `shared_ptr<State>` to `State*`
#### Cleaning
- cleaning the source code files